### PR TITLE
Add workflows for issue automation

### DIFF
--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -1,0 +1,15 @@
+name: Add issues to project
+on:
+  issues:
+    types:
+      - opened
+      - reopened
+jobs:
+  add-to-project:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Add to DevRel
+        uses: actions/add-to-project@v0.4.0
+        with:
+          project-url: https://github.com/orgs/pulumi/projects/47
+          github-token: ${{ secrets.PULUMI_BOT_GHA_MARKETING }}

--- a/.github/workflows/triage-new-issues.yml
+++ b/.github/workflows/triage-new-issues.yml
@@ -1,0 +1,21 @@
+name: Add triage label to new issues
+on:
+  issues:
+    types:
+      - opened
+      - reopened
+jobs:
+  triage-new-issues:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - uses: actions/github-script@v6
+        with:
+          script: |
+            github.rest.issues.addLabels({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              labels: ["needs-triage"]
+            })


### PR DESCRIPTION
This PR adds workflows to automatically add issues to DevRel project and to automatically tag new issues with "needs-triage" label.

Related to https://github.com/pulumi/zephyr-app/issues/5.